### PR TITLE
fix: Improper theme selector

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -4,7 +4,7 @@ not (-moz-bool-pref: "zen.view.use-single-toolbar") {
   @media not (-moz-bool-pref: "zen.view.compact.enable-at-startup"),
   not (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
 
-    body:has(#Zen-Auto-Expand-Sidebar[mod-autoexpand-performance-mode="potato"]) {
+    body:has(#theme-Zen-Auto-Expand-Sidebar[mod-autoexpand-performance-mode="potato"]) {
       #zen-media-focus-button{
       //transform: scaleY(2) !important;
       }


### PR DESCRIPTION
For the implementation of the potato performance setting, the selector tag was ```#Zen-Auto-Expand-Sidebar``` which is invalid as they are labeled ```#theme-Zen-Auto-Expand-Sidebar```. This pull request fixes that.