### PR TITLE
remove !important from .tab-close-button display

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -819,7 +819,7 @@ not (-moz-bool-pref: "zen.view.use-single-toolbar") {
         opacity 150ms ease-in-out !important;
         position: absolute;
         left: 0;
-        display: flex !important;
+        display: flex;
         opacity: 0% !important;
         margin-left: 4px !important;
       }
@@ -909,7 +909,7 @@ not (-moz-bool-pref: "zen.view.use-single-toolbar") {
       #navigator-toolbox:not([zen-right-side="true"]){
       tab:not([zen-essential], [zen-glance-tab="true"]){
         .tab-close-button{
-          display: flex !important;
+          display: flex;
           position: absolute !important;
           opacity: 0% !important;
           margin-right: 2px !important;


### PR DESCRIPTION
Hello, with this change i removed the !important tag from the tab closing X buttons display properties.

With this change the mod will be compatible with https://github.com/xXMacMillanXx/remove-tab-x

I tested the mod, and found no difference in functionality compared to before the change.